### PR TITLE
Return unmodified input if it is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ angular.module('nl2br-filter', [])
     }
 
     return function (input) {
+        if (typeof input == 'undefined') return input;
         var sanitizedInput = escapeHTML(input);
         var html = sanitizedInput.replace(/\n/g, '<br>');
 


### PR DESCRIPTION
When input is an undefined value, filter returns a string 'undefined' instead of nothing. This check fixes that issue.
